### PR TITLE
Could com.baidu:jprotobuf-rpc-ext-validator:4.2.1 drop off redundant dependencies?

### DIFF
--- a/jprotobuf-rpc-ext-validator/pom.xml
+++ b/jprotobuf-rpc-ext-validator/pom.xml
@@ -20,11 +20,32 @@
 			<groupId>org.jboss.forge.addon</groupId>
 			<artifactId>bean-validation</artifactId>
 			<version>2.16.1.Final</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>com.sun.mail</groupId>
+				    <artifactId>javax.mail</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.jboss.forge.addon</groupId>
+				    <artifactId>bean-validation-api</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.baidu</groupId>
 			<artifactId>jprotobuf-rpc-core</artifactId>
 			<version>${project.parent.version}</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>javax.servlet</groupId>
+				    <artifactId>servlet-api</artifactId>
+				</exclusion>
+		    	</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.hibernate</groupId>
+		    <artifactId>hibernate-validator</artifactId>
+		    <version>5.1.1.Final</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/78527112/167555235-091afc55-80c5-4560-b1b3-c2a6c8bb9134.png)

Hi! I found the pom file of project **_com.baidu:jprotobuf-rpc-ext-validator:4.2.1_** introduced **_25_** dependencies. However, among them, **_4_** libraries (**_16%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.jboss.forge.addon:bean-validation-api:jar:2.16.1.Final:compile
com.sun.mail:javax.mail:jar:1.5.0:compile
javax.activation:activation:jar:1.1:compile
javax.servlet:servlet-api:jar:2.4:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, As such, I suggest a refactoring operation for **_com.baidu:jprotobuf-rpc-ext-validator:4.2.1_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_org.hibernate:hibernate-validator::5.1.1.Final:compile_** are invoked by the projects. When we remove the redundant dependency **_org.jboss.forge.addon:bean-validation-api::2.16.1.Final:compile_**, the above **_org.hibernate:hibernate-validator::5.1.1.Final:compile_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.baidu:jprotobuf-rpc-ext-validator:4.2.1_**’s maven tests.

Best regards