### PR TITLE
修复 RpcChannel 中 netty 发送失败时未调用 callback 的问题

### DIFF
--- a/jprotobuf-rpc-core/src/main/java/com/baidu/jprotobuf/pbrpc/transport/handler/ErrorCodes.java
+++ b/jprotobuf-rpc-core/src/main/java/com/baidu/jprotobuf/pbrpc/transport/handler/ErrorCodes.java
@@ -36,6 +36,9 @@ public class ErrorCodes {
     /** read time out. */
     public static final int ST_READ_TIMEOUT = 62;
 
+    /** 消息发送异常. */
+    public static final int ST_WRITE_FAILED = 4001;
+
     /** onceTalkTimeout timeout message. */
     public static final String MSG_READ_TIMEOUT =
             "method request time out, please check 'onceTalkTimeout' property. current value is:";


### PR DESCRIPTION
Fixes #94.

在 RpcChannel 的netty发送失败时回调 callback，以保证正确的错误信息被透出以及加速失败的响应耗时。